### PR TITLE
面接登録・一覧表示機能の追加

### DIFF
--- a/app/assets/javascripts/interviews.coffee
+++ b/app/assets/javascripts/interviews.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -36,4 +36,25 @@ li {
   padding-left: 3px;
   padding-right: 3px; }
 
+#interview_scheduled_at_1i {
+  width:10%;
+}
+#interview_scheduled_at_2i {
+  width:10%;
+}
+#interview_scheduled_at_3i {
+  width:10%;
+}
+#interview_scheduled_at_4i {
+  width:10%;
+}
+#interview_scheduled_at_5i {
+  width:10%;
+}
+label {
+  display:block;
+}
 /*# sourceMappingURL=custom.css.map */
+.interviews > li {
+  display:block;
+}

--- a/app/assets/stylesheets/interviews.scss
+++ b/app/assets/stylesheets/interviews.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Interviews controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,12 +1,31 @@
 class InterviewsController < ApplicationController
-  before_action :set_user, only: [:index]
+  before_action :set_user, only: [:index,:new,:create]
   
   def index
-    @interviews =  Interview.find_by(user_id:@user.id)
+    @interviews =  Interview.where(user_id:@user.id)
     
   end
   
+  def new
+    @interview = Interview.new
+  end
+  
+  def create
+    @interview = Interview.new(interview_params)
+    if @interview.save
+      flash[:success] = "保存に成功しました"
+      redirect_to user_interviews_path(@user)
+    else
+      flash[:failure] = "保存に失敗しました"
+      render 'new'
+    end
+      
+  end
   private
+  
+  def interview_params
+    params.require(:interview).permit(:scheduled_at,:user_id)
+  end
   def set_user
     @user = User.find(params[:user_id])
   end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -12,6 +12,7 @@ class InterviewsController < ApplicationController
   
   def create
     @interview = Interview.new(interview_params)
+    @interview.user_id = current_user.id
     if @interview.save
       flash[:success] = "保存に成功しました"
       redirect_to user_interviews_path(@user)
@@ -24,7 +25,7 @@ class InterviewsController < ApplicationController
   private
   
   def interview_params
-    params.require(:interview).permit(:scheduled_at,:user_id)
+    params.require(:interview).permit(:scheduled_at)
   end
   def set_user
     @user = User.find(params[:user_id])

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -2,7 +2,7 @@ class InterviewsController < ApplicationController
   before_action :set_user, only: [:index,:new,:create]
   
   def index
-    @interviews =  Interview.where(user_id:@user.id)
+    @interviews =  @user.interviews
     
   end
   

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,0 +1,13 @@
+class InterviewsController < ApplicationController
+  before_action :set_user, only: [:index]
+  
+  def index
+    @interviews =  Interview.find_by(user_id:@user.id)
+    
+  end
+  
+  private
+  def set_user
+    @user = User.find(params[:user_id])
+  end
+end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -11,8 +11,7 @@ class InterviewsController < ApplicationController
   end
   
   def create
-    @interview = Interview.new(interview_params)
-    @interview.user_id = current_user.id
+    @interview = current_user.interviews.new(interview_params)
     if @interview.save
       flash[:success] = "保存に成功しました"
       redirect_to user_interviews_path(@user)

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,0 +1,2 @@
+module InterviewsHelper
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,0 +1,4 @@
+class Interview < ApplicationRecord
+  belongs_to :user
+  enum status: {approve:1, reject:2, hold:1}
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,4 +1,4 @@
 class Interview < ApplicationRecord
   belongs_to :user
-  enum status: {approve:1, reject:2, hold:1}
+  enum status: {approve:1, reject:2, hold:3}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :interviews
   enum gender: { male: 0, female: 1 }
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  has_many :interviews
+  has_many :interviews,dependent: :destroy
   enum gender: { male: 0, female: 1 }
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,0 +1,12 @@
+<h1>面接一覧</h2>
+<ul class="interviews">
+  <% if @interviews %>
+    <% @interviews.each do |interview| %>
+      <li>
+        <%=interview.scheduled_at%>
+        <%=interview.status%>
+        
+      </li>
+    <%end%>
+  <%end%>
+</ul>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -3,8 +3,8 @@
   <% if @interviews %>
     <% @interviews.each do |interview| %>
       <li>
-        <%=interview.scheduled_at%>
-        <%=interview.status%>
+        <%= interview.scheduled_at.strftime("%Y年%-m月%-d日 %-H時%-M分") %>
+        <%= interview.status %>
         
       </li>
     <%end%>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,12 +1,9 @@
 <h1>面接一覧</h2>
 <ul class="interviews">
-  <% if @interviews %>
     <% @interviews.each do |interview| %>
       <li>
         <%= interview.scheduled_at.strftime("%Y年%-m月%-d日 %-H時%-M分") %>
         <%= interview.status %>
-        
       </li>
     <%end%>
-  <%end%>
 </ul>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,0 +1,12 @@
+<!--面接情報を入力するためのフォーム-->
+<!--面接情報:は日時だけ-->
+<!--保存するためのボタンを作る-->
+
+<h1>新規面接作成</h1>
+<%= form_for(@interview, url:user_interviews_path(@user)) do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <%= f.hidden_field :user_id, :value => @user.id %>
+  <%= f.label "開始時間" %>
+  <%= f.datetime_select :scheduled_at, class: 'form-control' %>
+  <%= f.submit "送信", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,8 +13,10 @@
     <header>
     <ul class="navbar-nav" >
     <% if user_signed_in? %>
+      <li><%= link_to "ホーム", root_path, method: :get %><li>
       <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %><li>
       <li><%= link_to "プロフィール", edit_user_path(current_user), method: :get %></li>
+      <li><%= link_to "面接登録",  new_user_interview_path(current_user), method: :get %></li>
     <% end %>
     </ul>
     </header>

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,6 @@ module ENavigator
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
@@ -27,5 +26,7 @@ module ENavigator
     # Don't generate system test files.
     config.generators.system_tests = nil
     config.assets.initialize_on_precompile = false
+    #時刻を東京時間に修正する
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,8 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root "static_pages#home"
-  resources :users, :only => [:update, :edit,:show]
+  resources :users  do
+    resources :interviews
+  end
+  
 end

--- a/db/migrate/20190313125049_create_interviews.rb
+++ b/db/migrate/20190313125049_create_interviews.rb
@@ -1,0 +1,10 @@
+class CreateInterviews < ActiveRecord::Migration[5.1]
+  def change
+    create_table :interviews do |t|
+      t.integer :user_id
+      t.datetime :scheduled_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190313131219_add_status_to_interviews.rb
+++ b/db/migrate/20190313131219_add_status_to_interviews.rb
@@ -1,0 +1,5 @@
+class AddStatusToInterviews < ActiveRecord::Migration[5.1]
+  def change
+    add_column :interviews, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190213014425) do
+ActiveRecord::Schema.define(version: 20190313131219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "interviews", force: :cascade do |t|
+    t.integer "user_id"
+    t.datetime "scheduled_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "status"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false


### PR DESCRIPTION
やりたかったこと
- 面接一覧表示機能の追加
- 面接登録機能の追加

やったこと
- Interviewモデル・コントローラの追加
- Imterviewコントローラーのcreate,index,newメソッドなどの実装
- 面接登録ページの追加
- ホーム画面にログインユーザーの面接一覧を表示するようにビューの修正
- レイアウトに面接登録とホームへのリンクを設定

動作確認方法
- ユーザーでログインする
- 面接登録ボタンを押す
- 面接日程を登録する
- リダイレクトされた画面で面接一覧を確認する

